### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Gradle Build
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/rahulsom/genealogy/security/code-scanning/1](https://github.com/rahulsom/genealogy/security/code-scanning/1)

The best way to fix this problem is to add a `permissions` block to the workflow file (.github/workflows/build.yml), restricting the GITHUB_TOKEN permissions at the top level (root) or within the specific job. Since the workflow is delegating the build steps to a reusable workflow, the safest and minimal approach is to set the root-level permissions to `contents: read`, which covers most standard build scenarios, and can be adjusted as needed. If additional actions (e.g., creating releases or updating statuses) require more permissions, those specific types (`pull-requests: write`, etc.) can be added. For now, a minimal block set to `contents: read` should be added right after the workflow's `name` and before `on`, at the top of the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
